### PR TITLE
Add hubconf.py and automatic downloading of some pre-trained parameters

### DIFF
--- a/hubconf.py
+++ b/hubconf.py
@@ -1,2 +1,9 @@
+"""
+Example:
+``` py
+model = torch.hub.load('Ivan1248/Context-Aware-Consistency', 'DeepLabV3Plus', backbone='resnet50', num_classes=19, pretrained=True) 
+```
+"""
+
 from models.modeling.deeplab import DeepLab as DeepLabV3Plus
 from models import CAC

--- a/hubconf.py
+++ b/hubconf.py
@@ -1,0 +1,2 @@
+from models.modeling.deeplab import DeepLab as DeepLabV3Plus
+from models import CAC

--- a/models/modeling/backbone/__init__.py
+++ b/models/modeling/backbone/__init__.py
@@ -1,15 +1,15 @@
 from models.modeling.backbone import resnet, xception, drn, mobilenet
 
-def build_backbone(backbone, output_stride, BatchNorm):
+def build_backbone(backbone, output_stride, BatchNorm, pretrained=True):
     if backbone == 'resnet101':
-        return resnet.ResNet101(output_stride, BatchNorm)
+        return resnet.ResNet101(output_stride, BatchNorm, pretrained=pretrained)
     elif backbone == 'resnet50':
-        return resnet.ResNet50(output_stride, BatchNorm)
+        return resnet.ResNet50(output_stride, BatchNorm, pretrained=pretrained)
     elif backbone == 'xception':
-        return xception.AlignedXception(output_stride, BatchNorm)
+        return xception.AlignedXception(output_stride, BatchNorm, pretrained=pretrained)
     elif backbone == 'drn':
-        return drn.drn_d_54(BatchNorm)
+        return drn.drn_d_54(BatchNorm, pretrained=pretrained)
     elif backbone == 'mobilenet':
-        return mobilenet.MobileNetV2(output_stride, BatchNorm)
+        return mobilenet.MobileNetV2(output_stride, BatchNorm, pretrained=pretrained)
     else:
         raise NotImplementedError

--- a/models/modeling/backbone/drn.py
+++ b/models/modeling/backbone/drn.py
@@ -1,6 +1,6 @@
+import torch
 import torch.nn as nn
 import math
-import torch.utils.model_zoo as model_zoo
 from models.modeling.sync_batchnorm.batchnorm import SynchronizedBatchNorm2d
 
 webroot = 'http://dl.yf.io/drn/'
@@ -303,14 +303,14 @@ class DRN_A(nn.Module):
 def drn_a_50(BatchNorm, pretrained=True):
     model = DRN_A(Bottleneck, [3, 4, 6, 3], BatchNorm=BatchNorm)
     if pretrained:
-        model.load_state_dict(model_zoo.load_url(model_urls['resnet50']))
+        model.load_state_dict(torch.hub.load_state_dict_from_url(model_urls['resnet50']))
     return model
 
 
 def drn_c_26(BatchNorm, pretrained=True):
     model = DRN(BasicBlock, [1, 1, 2, 2, 2, 2, 1, 1], arch='C', BatchNorm=BatchNorm)
     if pretrained:
-        pretrained = model_zoo.load_url(model_urls['drn-c-26'])
+        pretrained = torch.hub.load_state_dict_from_url(model_urls['drn-c-26'])
         del pretrained['fc.weight']
         del pretrained['fc.bias']
         model.load_state_dict(pretrained)
@@ -320,7 +320,7 @@ def drn_c_26(BatchNorm, pretrained=True):
 def drn_c_42(BatchNorm, pretrained=True):
     model = DRN(BasicBlock, [1, 1, 3, 4, 6, 3, 1, 1], arch='C', BatchNorm=BatchNorm)
     if pretrained:
-        pretrained = model_zoo.load_url(model_urls['drn-c-42'])
+        pretrained = torch.hub.load_state_dict_from_url(model_urls['drn-c-42'])
         del pretrained['fc.weight']
         del pretrained['fc.bias']
         model.load_state_dict(pretrained)
@@ -330,7 +330,7 @@ def drn_c_42(BatchNorm, pretrained=True):
 def drn_c_58(BatchNorm, pretrained=True):
     model = DRN(Bottleneck, [1, 1, 3, 4, 6, 3, 1, 1], arch='C', BatchNorm=BatchNorm)
     if pretrained:
-        pretrained = model_zoo.load_url(model_urls['drn-c-58'])
+        pretrained = torch.hub.load_state_dict_from_url(model_urls['drn-c-58'])
         del pretrained['fc.weight']
         del pretrained['fc.bias']
         model.load_state_dict(pretrained)
@@ -340,7 +340,7 @@ def drn_c_58(BatchNorm, pretrained=True):
 def drn_d_22(BatchNorm, pretrained=True):
     model = DRN(BasicBlock, [1, 1, 2, 2, 2, 2, 1, 1], arch='D', BatchNorm=BatchNorm)
     if pretrained:
-        pretrained = model_zoo.load_url(model_urls['drn-d-22'])
+        pretrained = torch.hub.load_state_dict_from_url(model_urls['drn-d-22'])
         del pretrained['fc.weight']
         del pretrained['fc.bias']
         model.load_state_dict(pretrained)
@@ -350,7 +350,7 @@ def drn_d_22(BatchNorm, pretrained=True):
 def drn_d_24(BatchNorm, pretrained=True):
     model = DRN(BasicBlock, [1, 1, 2, 2, 2, 2, 2, 2], arch='D', BatchNorm=BatchNorm)
     if pretrained:
-        pretrained = model_zoo.load_url(model_urls['drn-d-24'])
+        pretrained = torch.hub.load_state_dict_from_url(model_urls['drn-d-24'])
         del pretrained['fc.weight']
         del pretrained['fc.bias']
         model.load_state_dict(pretrained)
@@ -360,7 +360,7 @@ def drn_d_24(BatchNorm, pretrained=True):
 def drn_d_38(BatchNorm, pretrained=True):
     model = DRN(BasicBlock, [1, 1, 3, 4, 6, 3, 1, 1], arch='D', BatchNorm=BatchNorm)
     if pretrained:
-        pretrained = model_zoo.load_url(model_urls['drn-d-38'])
+        pretrained = torch.hub.load_state_dict_from_url(model_urls['drn-d-38'])
         del pretrained['fc.weight']
         del pretrained['fc.bias']
         model.load_state_dict(pretrained)
@@ -370,7 +370,7 @@ def drn_d_38(BatchNorm, pretrained=True):
 def drn_d_40(BatchNorm, pretrained=True):
     model = DRN(BasicBlock, [1, 1, 3, 4, 6, 3, 2, 2], arch='D', BatchNorm=BatchNorm)
     if pretrained:
-        pretrained = model_zoo.load_url(model_urls['drn-d-40'])
+        pretrained = torch.hub.load_state_dict_from_url(model_urls['drn-d-40'])
         del pretrained['fc.weight']
         del pretrained['fc.bias']
         model.load_state_dict(pretrained)
@@ -380,7 +380,7 @@ def drn_d_40(BatchNorm, pretrained=True):
 def drn_d_54(BatchNorm, pretrained=True):
     model = DRN(Bottleneck, [1, 1, 3, 4, 6, 3, 1, 1], arch='D', BatchNorm=BatchNorm)
     if pretrained:
-        pretrained = model_zoo.load_url(model_urls['drn-d-54'])
+        pretrained = torch.hub.load_state_dict_from_url(model_urls['drn-d-54'])
         del pretrained['fc.weight']
         del pretrained['fc.bias']
         model.load_state_dict(pretrained)
@@ -390,7 +390,7 @@ def drn_d_54(BatchNorm, pretrained=True):
 def drn_d_105(BatchNorm, pretrained=True):
     model = DRN(Bottleneck, [1, 1, 3, 4, 23, 3, 1, 1], arch='D', BatchNorm=BatchNorm)
     if pretrained:
-        pretrained = model_zoo.load_url(model_urls['drn-d-105'])
+        pretrained = torch.hub.load_state_dict_from_url(model_urls['drn-d-105'])
         del pretrained['fc.weight']
         del pretrained['fc.bias']
         model.load_state_dict(pretrained)

--- a/models/modeling/backbone/mobilenet.py
+++ b/models/modeling/backbone/mobilenet.py
@@ -1,9 +1,7 @@
 import torch
 import torch.nn.functional as F
 import torch.nn as nn
-import math
 from models.modeling.sync_batchnorm.batchnorm import SynchronizedBatchNorm2d
-import torch.utils.model_zoo as model_zoo
 
 def conv_bn(inp, oup, stride, BatchNorm):
     return nn.Sequential(
@@ -121,7 +119,7 @@ class MobileNetV2(nn.Module):
         return x, low_level_feat
 
     def _load_pretrained_model(self):
-        pretrain_dict = model_zoo.load_url('http://jeff95.me/models/mobilenet_v2-6a65762b.pth')
+        pretrain_dict = torch.hub.load_state_dict_from_url('http://jeff95.me/models/mobilenet_v2-6a65762b.pth')
         model_dict = {}
         state_dict = self.state_dict()
         for k, v in pretrain_dict.items():

--- a/models/modeling/backbone/resnet.py
+++ b/models/modeling/backbone/resnet.py
@@ -146,7 +146,7 @@ class ResNet(nn.Module):
         from torchvision import models
         url = getattr(models, 'ResNet50_Weights').IMAGENET1K_V2.url
 
-        print(f"Load pretrained paremeters: {url}")
+        print(f"Load pretrained parameters: {url}")
         pretrain_dict = torch.hub.load_state_dict_from_url(url)
 
         state_dict = self.state_dict()

--- a/models/modeling/backbone/resnet.py
+++ b/models/modeling/backbone/resnet.py
@@ -143,8 +143,9 @@ class ResNet(nn.Module):
                 m.bias.data.zero_()
 
     def _load_pretrained_model(self):
-        from torchvision.models.resnet import model_urls
-        url = model_urls[f"resnet{self.resnet_layers}"]
+        from torchivision import models
+        url = getattr(models, 'ResNet50_Weights').IMAGENET1K_V2.url
+
         print(f"Load pretrained paremeters: {url}")
         pretrain_dict = torch.hub.load_state_dict_from_url(url)
 

--- a/models/modeling/backbone/resnet.py
+++ b/models/modeling/backbone/resnet.py
@@ -1,7 +1,7 @@
 import math
 import torch.nn as nn
 import torch.nn.functional as F
-import torch.utils.model_zoo as model_zoo
+import torch.hub
 import torch
 from models.modeling.sync_batchnorm.batchnorm import SynchronizedBatchNorm2d
 import os
@@ -143,27 +143,13 @@ class ResNet(nn.Module):
                 m.bias.data.zero_()
 
     def _load_pretrained_model(self):
-        # pretrain_dict = model_zoo.load_url('https://download.pytorch.org/models/resnet101-5d3b4d8f.pth')
-        if self.resnet_layers == 101:
-            path = 'pretrained/resnet101-5d3b4d8f.pth'
-        elif self.resnet_layers == 50:
-            path = 'pretrained/resnet50-19c8e357.pth'
-        else:
-            raise ValueError("{} layers not supported".format(self.resnet_layers))
+        from torchvision.models.resnet import model_urls
+        url = model_urls[f"resnet{self.resnet_layers}"]
+        print(f"Load pretrained paremeters: {url}")
+        pretrain_dict = torch.hub.load_state_dict_from_url(url)
 
-        if os.path.exists(path):
-            pretrain_dict = path
-        else:
-            raise ValueError("The path {} not exists".format(path))
-
-        print("load pretrained weight from {}".format(pretrain_dict))
-        pretrain_dict = torch.load(pretrain_dict)
-        model_dict = {}
         state_dict = self.state_dict()
-        for k, v in pretrain_dict.items():
-            if k in state_dict:
-                model_dict[k] = v
-        state_dict.update(model_dict)
+        state_dict.update({k: v for k, v in pretrain_dict.items() if k in state_dict})
         self.load_state_dict(state_dict)
 
 def ResNet101(output_stride, BatchNorm, pretrained=True):

--- a/models/modeling/backbone/resnet.py
+++ b/models/modeling/backbone/resnet.py
@@ -143,8 +143,9 @@ class ResNet(nn.Module):
                 m.bias.data.zero_()
 
     def _load_pretrained_model(self):
-        from torchvision.models.resnet import model_urls
-        url = model_urls[f"resnet{self.resnet_layers}"]
+        from torchvision import models
+        url = getattr(models, 'ResNet50_Weights').IMAGENET1K_V2.url
+
         print(f"Load pretrained paremeters: {url}")
         pretrain_dict = torch.hub.load_state_dict_from_url(url)
 

--- a/models/modeling/backbone/xception.py
+++ b/models/modeling/backbone/xception.py
@@ -2,7 +2,6 @@ import math
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-import torch.utils.model_zoo as model_zoo
 from models.modeling.sync_batchnorm.batchnorm import SynchronizedBatchNorm2d
 
 def fixed_padding(inputs, kernel_size, dilation):
@@ -248,7 +247,7 @@ class AlignedXception(nn.Module):
 
 
     def _load_pretrained_model(self):
-        pretrain_dict = model_zoo.load_url('http://data.lip6.fr/cadene/pretrainedmodels/xception-b5690688.pth')
+        pretrain_dict = torch.hub.load_state_dict_from_url('http://data.lip6.fr/cadene/pretrainedmodels/xception-b5690688.pth')
         model_dict = {}
         state_dict = self.state_dict()
 

--- a/models/modeling/deeplab.py
+++ b/models/modeling/deeplab.py
@@ -8,7 +8,7 @@ from models.modeling.backbone import build_backbone
 
 class DeepLab(nn.Module):
     def __init__(self, backbone='resnet101', output_stride=16, num_classes=21,
-                 sync_bn=False, freeze_bn=False):
+                 sync_bn=False, freeze_bn=False, pretrained=True):
         super(DeepLab, self).__init__()
         if backbone == 'drn':
             output_stride = 8
@@ -21,7 +21,7 @@ class DeepLab(nn.Module):
         else:
             BatchNorm = nn.BatchNorm2d
 
-        self.backbone = build_backbone(backbone, output_stride, BatchNorm)
+        self.backbone = build_backbone(backbone, output_stride, BatchNorm, pretrained=pretrained)
         self.aspp = build_aspp(backbone, output_stride, BatchNorm)
         self.decoder = build_decoder(num_classes, backbone, BatchNorm)
 

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,7 +1,6 @@
 import json
 import logging
 
-logging.basicConfig(level=logging.INFO, format='')
 
 class Logger:
     """


### PR DESCRIPTION
This adds `hubconf.py` so that, for example, the following can work when "Ivan1248" is replaced with "dvlab-research":
``` py
model = torch.hub.load('Ivan1248/Context-Aware-Consistency', 'DeepLabV3Plus', backbone='resnet50',
                       pretrained=True, num_classes=21)
```